### PR TITLE
Raise exception if device is unavailable during setup

### DIFF
--- a/dreambox/__init__.py
+++ b/dreambox/__init__.py
@@ -39,7 +39,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Dreambox from a config entry."""
     _async_import_options_from_data_if_missing(hass, entry)
     host = entry.data[CONF_HOST]


### PR DESCRIPTION
When Home Assistant gets restarted while the Dreambox is powered off, a fake device will get detected by HA with empty device information. Avoid that by raising a `ConfigEntryNotReady` exception until `api.deviceinfo` exists.
