### PR TITLE
Use async_forward_entry_setups

### DIFF
--- a/dreambox/__init__.py
+++ b/dreambox/__init__.py
@@ -53,10 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady("Failed to obtain device information")
 
     hass.data[DOMAIN][CONF_CONNECTIONS][entry.entry_id] = api
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
@@ -71,14 +68,7 @@ def _async_import_options_from_data_if_missing(hass, entry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in PLATFORMS
-            ]
-        )
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN][CONF_CONNECTIONS].pop(entry.entry_id)
 

--- a/dreambox/manifest.json
+++ b/dreambox/manifest.json
@@ -2,7 +2,7 @@
   "domain": "dreambox",
   "name": "Dreambox",
   "documentation": "https://www.home-assistant.io/integrations/dreambox",
-  "version" : "0.8",
+  "version" : "0.9",
   "codeowners": [
     "@sreichholf"
   ],


### PR DESCRIPTION
Hey @sreichholf! I hope you're doing fine.

`async_forward_entry_setup` was removed in HA 2025.6. This PR fixes loading the integration. It should work with versions starting ~2024.7.
